### PR TITLE
feat: add docker and docker compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Versioning and metadata
+.git
+.gitignore
+.dockerignore
+
+# Build dependencies
+dist.do
+node_modules
+
+# Environment (contains sensitive data)
+*.env
+
+# Misc
+.eslintrc.js
+.prettierrc
+README.md

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ nest start book
 
 # Use npm scripts
 # Eg. npm run <script> --  <service_name>
-npm run start -- book
-npm run start:dev -- book
-npm run start:prod -- book
-npm run build -- book
+npm run start book
+npm run start:dev book
+npm run build book
 ```

--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ npm run start book
 npm run start:dev book
 npm run build book
 ```
+
+The microservice requires MongoDB and RabbitMQ.
+Could run on docker images for these services, if do not have them installed.
+To run all the services in docker, could run:
+
+```bash
+# At project root
+docker-compose up -d
+```

--- a/apps/Dockerfile.service
+++ b/apps/Dockerfile.service
@@ -1,0 +1,30 @@
+ARG services
+
+FROM node:alpine As development
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+RUN npm run build auth
+
+FROM node:alpine as production
+
+ARG NODE_ENV=production
+ENV NODE_ENV=${NODE_ENV}
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install --only=production
+
+COPY . .
+
+COPY --from=development /usr/src/app/dist ./dist
+
+CMD ["node", "dist/apps/${services}/main"]

--- a/apps/Dockerfile.service
+++ b/apps/Dockerfile.service
@@ -1,4 +1,4 @@
-ARG services
+ARG service
 
 FROM node:alpine As development
 
@@ -10,7 +10,7 @@ RUN npm install
 
 COPY . .
 
-RUN npm run build auth
+RUN npm run build ${service}
 
 FROM node:alpine as production
 
@@ -27,4 +27,4 @@ COPY . .
 
 COPY --from=development /usr/src/app/dist ./dist
 
-CMD ["node", "dist/apps/${services}/main"]
+CMD ["node", "dist/apps/${service}/main"]

--- a/apps/book/.env
+++ b/apps/book/.env
@@ -1,1 +1,2 @@
 MONGODB_URI='mongodb://localhost/libraryapp-book'
+PORT=8001

--- a/apps/book/src/main.ts
+++ b/apps/book/src/main.ts
@@ -15,7 +15,7 @@ async function bootstrap() {
     .build();
 
   const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api', app, document);
+  SwaggerModule.setup('api', app, document, { customSiteTitle: 'Book' });
 
   const PORT = process.env.PORT || 8001;
   await app.listen(PORT);

--- a/apps/book/src/main.ts
+++ b/apps/book/src/main.ts
@@ -2,6 +2,8 @@ import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { BookModule } from './book.module';
 
+console.log('DB-URI', process.env.MONGODB_URI);
+
 async function bootstrap() {
   const app = await NestFactory.create(BookModule);
 

--- a/apps/book/src/main.ts
+++ b/apps/book/src/main.ts
@@ -17,6 +17,7 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
 
-  await app.listen(3000);
+  const PORT = process.env.PORT || 8001;
+  await app.listen(PORT);
 }
 bootstrap();

--- a/apps/borrowing/.env
+++ b/apps/borrowing/.env
@@ -2,3 +2,5 @@ MONGODB_URI='mongodb://localhost/libraryapp-borrowing'
 
 RABBIT_MQ_URI=amqp://localhost:5672
 RABBIT_MQ_PAYMENT_QUEUE=payment
+
+PORT=8003

--- a/apps/borrowing/src/main.ts
+++ b/apps/borrowing/src/main.ts
@@ -15,7 +15,7 @@ async function bootstrap() {
     .build();
 
   const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api', app, document);
+  SwaggerModule.setup('api', app, document, { customSiteTitle: 'Borrowing' });
 
   app.connectMicroservice(rmqService.getOptions('PAYMENT'));
   await app.startAllMicroservices();

--- a/apps/borrowing/src/main.ts
+++ b/apps/borrowing/src/main.ts
@@ -20,6 +20,7 @@ async function bootstrap() {
   app.connectMicroservice(rmqService.getOptions('PAYMENT'));
   await app.startAllMicroservices();
 
-  await app.listen(3002);
+  const PORT = process.env.PORT || 8003;
+  await app.listen(PORT);
 }
 bootstrap();

--- a/apps/customer/.env
+++ b/apps/customer/.env
@@ -1,1 +1,2 @@
 MONGODB_URI='mongodb://localhost/libraryapp-customer'
+PORT=8002

--- a/apps/customer/src/main.ts
+++ b/apps/customer/src/main.ts
@@ -13,7 +13,7 @@ async function bootstrap() {
     .build();
 
   const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api', app, document);
+  SwaggerModule.setup('api', app, document, { customSiteTitle: 'Customer' });
 
   const PORT = process.env.PORT || 8002;
   await app.listen(PORT);

--- a/apps/customer/src/main.ts
+++ b/apps/customer/src/main.ts
@@ -15,6 +15,7 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
 
-  await app.listen(3001);
+  const PORT = process.env.PORT || 8002;
+  await app.listen(PORT);
 }
 bootstrap();

--- a/apps/payment/.env
+++ b/apps/payment/.env
@@ -2,3 +2,5 @@ MONGODB_URI='mongodb://localhost/libraryapp-payment'
 
 RABBIT_MQ_URI=amqp://localhost:5672
 RABBIT_MQ_PAYMENT_QUEUE=payment
+
+PORT=8004

--- a/apps/payment/src/main.ts
+++ b/apps/payment/src/main.ts
@@ -15,7 +15,7 @@ async function bootstrap() {
     .build();
 
   const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api', app, document);
+  SwaggerModule.setup('api', app, document, { customSiteTitle: 'Payment' });
 
   app.connectMicroservice(rmqService.getOptions('PAYMENT'));
   await app.startAllMicroservices();

--- a/apps/payment/src/main.ts
+++ b/apps/payment/src/main.ts
@@ -20,6 +20,7 @@ async function bootstrap() {
   app.connectMicroservice(rmqService.getOptions('PAYMENT'));
   await app.startAllMicroservices();
 
-  await app.listen(3003);
+  const PORT = process.env.PORT || 8004;
+  await app.listen(PORT);
 }
 bootstrap();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  # app Services
+  # app services
   book:
     build:
       context: .
@@ -23,29 +23,82 @@ services:
       - node-network
     links:
       - mongodb
-  # customer:
-  #   build:
-  #     context: .
-  #     dockerfile: ./apps/Dockerfile.service
-  #     target: development
-  #     args:
-  #       service: customer
-  #   command: npm run start:dev customer
-  #   env_file:
-  #     - ./apps/book/.env
-  #   environment:
-  #     - MONGODB_URI=mongodb://mongodb:27017/libraryapp-customer
-  #   depends_on:
-  #     - mongodb
-  #   volumes:
-  #     - .:/usr/src/app
-  #     - /usr/src/app/node_modules
-  #   ports:
-  #     - '8002:8002'
-  #   networks:
-  #     - node-network
-  #   links:
-  #     - mongodb
+  customer:
+    build:
+      context: .
+      dockerfile: ./apps/Dockerfile.service
+      target: development
+      args:
+        service: customer
+    command: npm run start:dev customer
+    env_file:
+      - ./apps/customer/.env
+    environment:
+      - MONGODB_URI=mongodb://mongodb:27017/libraryapp-customer
+    depends_on:
+      - mongodb
+    volumes:
+      - .:/usr/src/app
+      - /usr/src/app/node_modules
+    ports:
+      - '8002:8002'
+    networks:
+      - node-network
+    links:
+      - mongodb
+  borrowing:
+    build:
+      context: .
+      dockerfile: ./apps/Dockerfile.service
+      target: development
+      args:
+        service: borrowing
+    command: npm run start:dev borrowing
+    env_file:
+      - ./apps/borrowing/.env
+    environment:
+      - MONGODB_URI=mongodb://mongodb:27017/libraryapp-borrowing
+      - RABBIT_MQ_URI=amqp://rabbitmq:5672
+    depends_on:
+      - mongodb
+      - rabbitmq
+    volumes:
+      - .:/usr/src/app
+      - /usr/src/app/node_modules
+    ports:
+      - '8003:8003'
+    networks:
+      - node-network
+    links:
+      - mongodb
+      - rabbitmq
+  payment:
+    build:
+      context: .
+      dockerfile: ./apps/Dockerfile.service
+      target: development
+      args:
+        service: payment
+    command: npm run start:dev payment
+    env_file:
+      - ./apps/payment/.env
+    environment:
+      - MONGODB_URI=mongodb://mongodb:27017/libraryapp-payment
+      - RABBIT_MQ_URI=amqp://rabbitmq:5672
+    depends_on:
+      - mongodb
+      - rabbitmq
+    volumes:
+      - .:/usr/src/app
+      - /usr/src/app/node_modules
+    ports:
+      - '8004:8004'
+    networks:
+      - node-network
+    links:
+      - mongodb
+      - rabbitmq
+
   # Dependencies
   rabbitmq:
     image: rabbitmq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,69 @@
+services:
+  # app Services
+  book:
+    build:
+      context: .
+      dockerfile: ./apps/Dockerfile.service
+      target: development
+      args:
+        service: book
+    command: npm run start:dev book
+    env_file:
+      - ./apps/book/.env
+    environment:
+      - MONGODB_URI=mongodb://mongodb:27017/libraryapp-book
+    depends_on:
+      - mongodb
+    volumes:
+      - .:/usr/src/app
+      - /usr/src/app/node_modules
+    ports:
+      - '8001:8001'
+    networks:
+      - node-network
+    links:
+      - mongodb
+  # customer:
+  #   build:
+  #     context: .
+  #     dockerfile: ./apps/Dockerfile.service
+  #     target: development
+  #     args:
+  #       service: customer
+  #   command: npm run start:dev customer
+  #   env_file:
+  #     - ./apps/book/.env
+  #   environment:
+  #     - MONGODB_URI=mongodb://mongodb:27017/libraryapp-customer
+  #   depends_on:
+  #     - mongodb
+  #   volumes:
+  #     - .:/usr/src/app
+  #     - /usr/src/app/node_modules
+  #   ports:
+  #     - '8002:8002'
+  #   networks:
+  #     - node-network
+  #   links:
+  #     - mongodb
+  # Dependencies
+  rabbitmq:
+    image: rabbitmq
+    ports:
+      - '5672:5672'
+    networks:
+      - node-network
+  mongodb:
+    image: mongo:6
+    volumes:
+      - mongodb_data_container:/data/db
+    ports:
+      - '27017:27017'
+    networks:
+      - node-network
+volumes:
+  mongodb_data_container:
+networks:
+  node-network:
+    driver: bridge
+# docker-compose up -d


### PR DESCRIPTION
Add docker and docker compose, to able to run the entire microservice via docker compose.
Would solve the dependency requirement for MongoDB and RabbitMQ.